### PR TITLE
feature: rename the CHANGELOG.md file to maintain history but not aff…

### DIFF
--- a/module-splitter.sh
+++ b/module-splitter.sh
@@ -67,6 +67,12 @@ function prepare_donor() {
     git clone --no-tags --single-branch --branch=main https://github.com/$ORG/$DONOR.git
     cd $DONOR || exit 1
     echo "Extracting module: $MODULE"
+    # Check if CHANGELOG.md exists and rename it to OLD_CHANGELOG.md
+    if [ -f "CHANGELOG.md" ]; then
+        echo "Renaming CHANGELOG.md to OLD_CHANGELOG.md"
+        mv CHANGELOG.md OLD_CHANGELOG.md
+        git commit -a -m "Rename CHANGELOG.md to OLD_CHANGELOG.md"
+    fi
     git subtree split -P $MODULE -b split/$MODULE
     # Fix up the history so it conforms to conventional commit standards
     echo "Fixing up commit messages"


### PR DESCRIPTION
…ect differing formats

CHANGELOG formats change between monorepo and extracted repositories.  This change renames the CHANGELOG file so as to maintain the history but allow the change log of the new repo to exist